### PR TITLE
Исправлена ошибка json_decode()

### DIFF
--- a/core/components/gl/elements/snippets/snippet.location.php
+++ b/core/components/gl/elements/snippets/snippet.location.php
@@ -27,7 +27,11 @@ $where = array(
 );
 
 if (!empty($scriptProperties['where'])) {
-    $tmp = $modx->fromJSON($scriptProperties['where']);
+    if (is_array($scriptProperties['where'])) {
+        $tmp = $scriptProperties['where'];
+    } else {
+        $tmp = $modx->fromJSON($scriptProperties['where']);
+    }
     if (is_array($tmp) AND !empty($tmp)) {
         $where = array_merge($where, $tmp);
     }


### PR DESCRIPTION
Исправляет ошибку "json_decode() expects parameter 1 to be string, array given", если используется синтаксис Fenom для вызова сниппета:
```
{'!gl.location' | snippet : [
    'limit' => 0,
    'class' => $_modx->getPlaceholder('class'),
    'where' => [
	    'default' => 0
    ],
]}
```